### PR TITLE
Titleize

### DIFF
--- a/command/model_command.go
+++ b/command/model_command.go
@@ -45,7 +45,7 @@ func processFields(args []string) map[string]string {
 
 // Execute runs this command.
 func (command *ModelCommand) Execute(args []string) {
-	command.ModelName = args[0]
+	command.ModelName = command.ModelName = inflect.Titleize(args[0])
 	command.ModelNamePlural = inflect.Pluralize(command.ModelName)
 
 	command.Fields = processFields(args[1:])


### PR DESCRIPTION
because of importing model package is failed in case below.
`gin-scaffold scaffold hoge name:int`

```
type hoge struct {
```

hoge should be `Hoge`.